### PR TITLE
Add question detail view

### DIFF
--- a/poll/main/templates/main/base.html
+++ b/poll/main/templates/main/base.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}Poll{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQjaB40MUxC92+Jh4jB+Y88ef0qLj+AEAP9I1y5I5O2VJBr+74Cz2UqKw" crossorigin="anonymous">
+  </head>
+  <body>
+    <div class="container py-4">
+      {% block content %}{% endblock %}
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-EMg2xO7ybL5JU+4EZIdzoPt60h5ASO69dN9dlywF2q8O9p6VR1oK6czSlsCwFgRr" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/poll/main/templates/main/question_detail.html
+++ b/poll/main/templates/main/question_detail.html
@@ -1,0 +1,69 @@
+{% extends "main/base.html" %}
+
+{% block title %}Question Detail{% endblock %}
+
+{% block content %}
+<h1 class="mb-4">Question Detail</h1>
+<div class="mb-3">
+  <strong>Topic template:</strong>
+  <pre>{{ question.template }}</pre>
+</div>
+<div class="mb-3">
+  <strong>Number of question variations:</strong> {{ num_variations }}
+</div>
+<div class="mb-3">
+  <strong>Total LLM queries:</strong> {{ total_queries }}
+</div>
+
+<h2 class="mt-5">Batches</h2>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>Batch ID</th>
+      <th>Status</th>
+      <th>Created</th>
+      <th>Updated</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for batch in batches %}
+    <tr>
+      <td>{{ batch.batch_id }}</td>
+      <td>{{ batch.status }}</td>
+      <td>{{ batch.created_at }}</td>
+      <td>{{ batch.updated_at }}</td>
+    </tr>
+    {% empty %}
+    <tr>
+      <td colspan="4" class="text-center">No batches.</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<h2 class="mt-5">Answers</h2>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>Context</th>
+      <th>Choices</th>
+      <th>Choice</th>
+      <th>Confidence</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for answer in answers %}
+    <tr>
+      <td><code>{{ answer.context }}</code></td>
+      <td>A: {{ answer.choices.A }}<br>B: {{ answer.choices.B }}</td>
+      <td>{{ answer.choice }}</td>
+      <td>{{ answer.confidence }}</td>
+    </tr>
+    {% empty %}
+    <tr>
+      <td colspan="4" class="text-center">No answers.</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/poll/main/urls.py
+++ b/poll/main/urls.py
@@ -5,4 +5,5 @@ from . import views
 app_name = 'polls'
 
 urlpatterns = [
+    path('<uuid:uuid>/', views.question_detail, name='question_detail'),
 ]

--- a/poll/main/views.py
+++ b/poll/main/views.py
@@ -1,0 +1,22 @@
+from django.shortcuts import get_object_or_404, render
+
+from .models import Question, Answer
+
+
+def question_detail(request, uuid):
+    question = get_object_or_404(Question, uuid=uuid)
+    rendered_questions = question.render_all_questions()
+    num_variations = len(rendered_questions)
+    choice_pairs = question.choice_pairs()
+    total_queries = len(rendered_questions) * len(choice_pairs)
+    batches = question.openai_batches.all().order_by("-created_at")
+    answers = Answer.objects.filter(question=question)
+
+    context = {
+        "question": question,
+        "num_variations": num_variations,
+        "total_queries": total_queries,
+        "batches": batches,
+        "answers": answers,
+    }
+    return render(request, "main/question_detail.html", context)


### PR DESCRIPTION
## Summary
- add Bootstrap-based base template and question detail template
- implement question_detail view to show question summary, batches and answers
- wire up URL pattern for the detail view
- tweak tests for OpenAI response_format change
- add unit test for question_detail view

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_686e14b9c3908328a1a66acf64ff863f