### PR TITLE
Store OpenAI batch metadata as JSON

### DIFF
--- a/poll/main/admin.py
+++ b/poll/main/admin.py
@@ -26,7 +26,6 @@ class AnswerAdmin(admin.ModelAdmin):
 @admin.register(OpenAIBatch)
 class OpenAIBatchAdmin(admin.ModelAdmin):
     list_display = ["batch_id", "status", "created_at", "updated_at"]
-    list_filter = ["status"]
     actions = [
         'update_status',
         'retrieve_results'

--- a/poll/main/migrations/0013_openaibatch_data_json.py
+++ b/poll/main/migrations/0013_openaibatch_data_json.py
@@ -1,0 +1,36 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("main", "0012_alter_question_uuid"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="openaibatch",
+            name="data",
+            field=models.JSONField(default=dict),
+        ),
+        migrations.RemoveField(
+            model_name="openaibatch",
+            name="batch_id",
+        ),
+        migrations.RemoveField(
+            model_name="openaibatch",
+            name="status",
+        ),
+        migrations.RemoveField(
+            model_name="openaibatch",
+            name="errors",
+        ),
+        migrations.RemoveField(
+            model_name="openaibatch",
+            name="error_file_id",
+        ),
+        migrations.RemoveField(
+            model_name="openaibatch",
+            name="output_file_id",
+        ),
+    ]

--- a/poll/main/tests.py
+++ b/poll/main/tests.py
@@ -45,9 +45,7 @@ class OpenAIBatchModelTests(TestCase):
         q = Question.objects.create(template="dummy", choices=["A", "B"])
         batch = OpenAIBatch.objects.create(
             question=q,
-            batch_id="batch_1",
-            status="completed",
-            output_file_id="file_123",
+            data={"id": "batch_1", "status": "completed", "output_file_id": "file_123"},
         )
 
         fake_content = (


### PR DESCRIPTION
## Summary
- simplify `OpenAIBatch` by replacing individual fields with a JSON `data` field
- update admin to use property based fields
- save full OpenAI batch response when submitting
- adjust tests
- add migration

## Testing
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_b_686e3529a62483288121d47bd677b900