### PR TITLE
Adapt questions to plain text

### DIFF
--- a/poll/main/templates/main/question_detail.html
+++ b/poll/main/templates/main/question_detail.html
@@ -5,8 +5,8 @@
 {% block content %}
 <h1 class="mb-4">Question Detail</h1>
 <div class="mb-3">
-  <strong>Topic template:</strong>
-  <pre>{{ question.template }}</pre>
+  <strong>Question text:</strong>
+  <pre>{{ question.text }}</pre>
 </div>
 <div class="mb-3">
   <strong>Number of question variations:</strong> {{ num_variations }}

--- a/poll/main/tests.py
+++ b/poll/main/tests.py
@@ -11,24 +11,24 @@ from .models import Question, OpenAIBatch, Answer
 class QuestionModelTests(TestCase):
     def test_render_all_questions(self):
         q = Question.objects.create(
-            template="Where would a {{ gender }} move?",
+            text="Where would a person move?",
             context={"gender": ["man", "woman"]},
         )
         expected = [
-            ("Where would a man move?", {"gender": "man"}),
-            ("Where would a woman move?", {"gender": "woman"}),
+            ("Where would a person move?", {"gender": "man"}),
+            ("Where would a person move?", {"gender": "woman"}),
         ]
         self.assertEqual(q.render_all_questions(), expected)
 
     def test_choice_pairs_deduplicated(self):
         q = Question.objects.create(
-            template="dummy",
+            text="dummy",
             choices=["A", "A", "B"],
         )
         self.assertEqual(q.choice_pairs(), [{"A": "A", "B": "B"}])
 
     def test_get_openai_batches_contains_response_format(self):
-        q = Question.objects.create(template="q", choices=["A", "B"])
+        q = Question.objects.create(text="q", choices=["A", "B"])
         batches = q.get_openai_batches()
         self.assertEqual(len(batches), 1)
         line = batches[0].splitlines()[0]
@@ -40,7 +40,7 @@ class QuestionModelTests(TestCase):
         self.assertEqual(schema_props["confidence"]["type"], "number")
 
     def test_submit_batches_assigns_single_run_id(self):
-        q = Question.objects.create(template="q", choices=["A", "B"])
+        q = Question.objects.create(text="q", choices=["A", "B"])
         mock_client = Mock()
         mock_client.files.create.return_value = Mock(id="file_1")
         mock_client.batches.create.return_value = Mock(model_dump=Mock(return_value={"id": "batch_1"}))
@@ -59,7 +59,7 @@ class QuestionModelTests(TestCase):
 class OpenAIBatchModelTests(TestCase):
     def test_retrieve_results_creates_answers(self):
         q = Question.objects.create(
-            template="Where would a {{ gender }} from {{ country }} prefer to move?",
+            text="Where would a person prefer to move?",
             context={"country": ["Turkey"], "gender": ["man"]},
             choices=["Turkey", "Mexico"],
         )
@@ -101,7 +101,7 @@ class OpenAIBatchModelTests(TestCase):
 
 class QuestionDetailViewTests(TestCase):
     def test_question_detail_view(self):
-        q = Question.objects.create(template="example", choices=["A", "B"])
+        q = Question.objects.create(text="example", choices=["A", "B"])
         a = Answer.objects.create(
             question=q,
             context={},


### PR DESCRIPTION
## Summary
- update question model helpers for plain text rather than templates
- adjust OpenAI batch creation to include developer and user messages
- update HTML template to show question text
- update tests for new text-based behaviour

## Testing
- `python manage.py test -v 0`

------
https://chatgpt.com/codex/tasks/task_b_686f6e8b1540832889f95da477fc8058