### PR TITLE
Add preference counts chart

### DIFF
--- a/poll/main/templates/main/question_detail.html
+++ b/poll/main/templates/main/question_detail.html
@@ -46,6 +46,32 @@
 <p>
   <a class="btn btn-primary" href="{% url 'polls:question_answers_csv' question.uuid %}">Download CSV</a>
 </p>
+
+<h2 class="mt-5">Big-picture preference counts</h2>
+<canvas id="preferenceChart" height="120"></canvas>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" crossorigin="anonymous"></script>
+<script>
+  const prefData = {{ preference_counts_json|safe }};
+  const ctx = document.getElementById('preferenceChart').getContext('2d');
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: Object.keys(prefData),
+      datasets: [{
+        label: 'Preference count',
+        data: Object.values(prefData),
+        backgroundColor: 'rgba(54, 162, 235, 0.5)',
+        borderColor: 'rgba(54, 162, 235, 1)',
+        borderWidth: 1
+      }]
+    },
+    options: {
+      scales: {
+        y: { beginAtZero: true, ticks: { precision: 0 } }
+      }
+    }
+  });
+</script>
 {% else %}
 <p>No answers.</p>
 {% endif %}

--- a/poll/main/tests.py
+++ b/poll/main/tests.py
@@ -136,6 +136,9 @@ class QuestionDetailViewTests(TestCase):
         self.assertEqual(response.context["total_queries"], 1)
         self.assertTrue(response.context["has_answers"])
         self.assertContains(response, "Download CSV")
+        self.assertIn("preference_counts", response.context)
+        self.assertEqual(response.context["preference_counts"], {"A": 1})
+        self.assertContains(response, "preferenceChart")
 
     def test_question_answers_csv_view(self):
         q = Question.objects.create(text="q", choices=["A", "B"])

--- a/poll/main/views.py
+++ b/poll/main/views.py
@@ -14,7 +14,14 @@ def question_detail(request, uuid):
     total_queries = len(rendered_questions) * len(choice_pairs)
     batches = question.openai_batches.all().order_by("-created_at")
 
-    has_answers = question.latest_answers().exists()
+    answers = question.latest_answers()
+    has_answers = answers.exists()
+
+    preference_counts: dict[str, int] = {}
+    for ans in answers:
+        chosen = ans.choices.get(ans.choice)
+        if chosen:
+            preference_counts[chosen] = preference_counts.get(chosen, 0) + 1
 
     context = {
         "question": question,
@@ -22,6 +29,8 @@ def question_detail(request, uuid):
         "total_queries": total_queries,
         "batches": batches,
         "has_answers": has_answers,
+        "preference_counts": preference_counts,
+        "preference_counts_json": json.dumps(preference_counts),
     }
     return render(request, "main/question_detail.html", context)
 


### PR DESCRIPTION
## Summary
- add a bar chart showing preference counts for each option
- compute counts in `question_detail` view
- display chart on the question detail template
- test new context data and chart rendering

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_686fca2b81608328b43eb530bdb11f1c