### PR TITLE
Add head-to-head heatmap chart

### DIFF
--- a/poll/api.py
+++ b/poll/api.py
@@ -25,4 +25,35 @@ def preference_counts(request, uuid: str):
 
     return {"counts": counts}
 
+
+@chart_router.get("questions/{uuid}/preference-heatmap")
+def preference_heatmap(request, uuid: str):
+    """Return head-to-head win counts for all choice pairs."""
+    question = get_object_or_404(Question, uuid=uuid)
+    answers = question.latest_answers()
+
+    for key in question.context.keys():
+        value = request.GET.get(key)
+        if value:
+            answers = answers.filter(**{f"context__{key}": value})
+
+    choices = list(dict.fromkeys(question.choices or []))
+    index = {c: i for i, c in enumerate(choices)}
+    size = len(choices)
+    matrix: list[list[int | None]] = [
+        [None if i == j else 0 for j in range(size)] for i in range(size)
+    ]
+
+    for ans in answers:
+        a = ans.choices.get("A")
+        b = ans.choices.get("B")
+        if a not in index or b not in index:
+            continue
+        if ans.choice == "A":
+            matrix[index[a]][index[b]] += 1  # type: ignore[operator]
+        elif ans.choice == "B":
+            matrix[index[b]][index[a]] += 1  # type: ignore[operator]
+
+    return {"choices": choices, "matrix": matrix}
+
 api.add_router("/charts/", chart_router)

--- a/poll/main/templates/main/question_detail.html
+++ b/poll/main/templates/main/question_detail.html
@@ -62,12 +62,17 @@
   {% endfor %}
 </div>
 <canvas id="preferenceChart" height="120"></canvas>
+<h3 class="mt-4">Head-to-head heatmap</h3>
+<canvas id="heatmapChart" height="300"></canvas>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@1.3.0/dist/chartjs-chart-matrix.min.js" crossorigin="anonymous"></script>
 <script>
   const questionUuid = "{{ question.uuid }}";
   const ctx = document.getElementById('preferenceChart').getContext('2d');
+  const heatCtx = document.getElementById('heatmapChart').getContext('2d');
   const filters = document.querySelectorAll('.context-filter');
   let chart;
+  let heatmap;
 
   async function loadChart() {
     const params = new URLSearchParams();
@@ -101,8 +106,65 @@
     }
   }
 
-  filters.forEach(sel => sel.addEventListener('change', loadChart));
-  loadChart();
+  async function loadHeatmap() {
+    const params = new URLSearchParams();
+    filters.forEach(sel => { if (sel.value) params.append(sel.dataset.key, sel.value); });
+    const resp = await fetch(`/api/charts/questions/${questionUuid}/preference-heatmap?` + params.toString());
+    const data = await resp.json();
+    const labels = data.choices || [];
+    const matrix = data.matrix || [];
+    const dataset = [];
+    let max = 0;
+    for (let y = 0; y < matrix.length; y++) {
+      for (let x = 0; x < matrix.length; x++) {
+        const v = matrix[y][x];
+        if (v === null) continue;
+        dataset.push({x, y, v});
+        if (v > max) max = v;
+      }
+    }
+
+    const color = v => `rgba(75, 192, 192, ${max ? v / max : 0})`;
+
+    if (heatmap) {
+      heatmap.data.datasets[0].data = dataset;
+      heatmap.options.scales.x.labels = labels;
+      heatmap.options.scales.y.labels = labels;
+      heatmap.update();
+    } else {
+      heatmap = new Chart(heatCtx, {
+        type: 'matrix',
+        data: {
+          datasets: [{
+            label: 'Win count',
+            data: dataset,
+            backgroundColor(ctx) {
+              const v = ctx.dataset.data[ctx.dataIndex].v;
+              return color(v);
+            },
+            width: (ctx) => {
+              const area = ctx.chart.chartArea;
+              return area ? (area.width / labels.length) - 1 : 0;
+            },
+            height: (ctx) => {
+              const area = ctx.chart.chartArea;
+              return area ? (area.height / labels.length) - 1 : 0;
+            },
+          }]
+        },
+        options: {
+          scales: {
+            x: {type: 'category', labels: labels, position: 'top'},
+            y: {type: 'category', labels: labels, reverse: true}
+          },
+        }
+      });
+    }
+  }
+
+  function reloadAll() { loadChart(); loadHeatmap(); }
+  filters.forEach(sel => sel.addEventListener('change', reloadAll));
+  reloadAll();
 </script>
 {% else %}
 <p>No answers.</p>

--- a/poll/main/tests.py
+++ b/poll/main/tests.py
@@ -229,3 +229,20 @@ class ChartAPITests(TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(data["counts"], {"X": 1})
+
+    def test_preference_heatmap_endpoint(self):
+        url = f"/api/charts/questions/{self.question.uuid}/preference-heatmap"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["choices"], ["X", "Y"])
+        self.assertEqual(data["matrix"][0][1], 1)
+        self.assertEqual(data["matrix"][1][0], 1)
+
+    def test_preference_heatmap_endpoint_filter(self):
+        url = f"/api/charts/questions/{self.question.uuid}/preference-heatmap?gender=man"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["matrix"][0][1], 1)
+        self.assertEqual(data["matrix"][1][0], 0)


### PR DESCRIPTION
## Summary
- add `/api/charts/questions/<uuid>/preference-heatmap` endpoint
- show heatmap for pairwise results using Chart.js matrix
- test new API endpoints
- fix heatmap chart cell sizing

## Testing
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_b_686fdba6940483289637a8359080436d