### PR TITLE
Add Elo league-table endpoint and chart

### DIFF
--- a/poll/api.py
+++ b/poll/api.py
@@ -56,4 +56,46 @@ def preference_heatmap(request, uuid: str):
 
     return {"choices": choices, "matrix": matrix}
 
+
+@chart_router.get("questions/{uuid}/elo-ratings")
+def elo_ratings(request, uuid: str):
+    """Return Elo-style rankings for all choices."""
+    question = get_object_or_404(Question, uuid=uuid)
+    answers = question.latest_answers().order_by("pk")
+
+    for key in question.context.keys():
+        value = request.GET.get(key)
+        if value:
+            answers = answers.filter(**{f"context__{key}": value})
+
+    choices = list(dict.fromkeys(question.choices or []))
+    ratings: dict[str, float] = {c: 1000.0 for c in choices}
+    K = 32
+
+    for ans in answers:
+        a = ans.choices.get("A")
+        b = ans.choices.get("B")
+        if a not in ratings or b not in ratings:
+            continue
+        ra = ratings[a]
+        rb = ratings[b]
+        expected_a = 1 / (1 + 10 ** ((rb - ra) / 400))
+        expected_b = 1 - expected_a
+        if ans.choice == "A":
+            sa, sb = 1, 0
+        elif ans.choice == "B":
+            sa, sb = 0, 1
+        else:
+            continue
+        ratings[a] = ra + K * (sa - expected_a)
+        ratings[b] = rb + K * (sb - expected_b)
+
+    ranking = sorted(
+        ({"choice": c, "rating": round(r, 2)} for c, r in ratings.items()),
+        key=lambda x: x["rating"],
+        reverse=True,
+    )
+
+    return {"rankings": ranking}
+
 api.add_router("/charts/", chart_router)

--- a/poll/main/templates/main/question_detail.html
+++ b/poll/main/templates/main/question_detail.html
@@ -64,15 +64,19 @@
 <canvas id="preferenceChart" height="120"></canvas>
 <h3 class="mt-4">Head-to-head heatmap</h3>
 <canvas id="heatmapChart" height="300"></canvas>
+<h3 class="mt-4">Ranked league table</h3>
+<canvas id="eloChart" height="150"></canvas>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@1.3.0/dist/chartjs-chart-matrix.min.js" crossorigin="anonymous"></script>
 <script>
   const questionUuid = "{{ question.uuid }}";
   const ctx = document.getElementById('preferenceChart').getContext('2d');
   const heatCtx = document.getElementById('heatmapChart').getContext('2d');
+  const eloCtx = document.getElementById('eloChart').getContext('2d');
   const filters = document.querySelectorAll('.context-filter');
   let chart;
   let heatmap;
+  let eloChart;
 
   async function loadChart() {
     const params = new URLSearchParams();
@@ -162,7 +166,39 @@
     }
   }
 
-  function reloadAll() { loadChart(); loadHeatmap(); }
+  async function loadElo() {
+    const params = new URLSearchParams();
+    filters.forEach(sel => { if (sel.value) params.append(sel.dataset.key, sel.value); });
+    const resp = await fetch(`/api/charts/questions/${questionUuid}/elo-ratings?` + params.toString());
+    const data = await resp.json();
+    const rows = data.rankings || [];
+    const labels = rows.map(r => r.choice);
+    const ratings = rows.map(r => r.rating);
+    if (eloChart) {
+      eloChart.data.labels = labels;
+      eloChart.data.datasets[0].data = ratings;
+      eloChart.update();
+    } else {
+      eloChart = new Chart(eloCtx, {
+        type: 'bar',
+        data: {
+          labels: labels,
+          datasets: [{
+            label: 'Elo rating',
+            data: ratings,
+            backgroundColor: 'rgba(255, 99, 132, 0.5)',
+            borderColor: 'rgba(255, 99, 132, 1)',
+            borderWidth: 1
+          }]
+        },
+        options: {
+          scales: { y: { beginAtZero: true } }
+        }
+      });
+    }
+  }
+
+  function reloadAll() { loadChart(); loadHeatmap(); loadElo(); }
   filters.forEach(sel => sel.addEventListener('change', reloadAll));
   reloadAll();
 </script>

--- a/poll/main/tests.py
+++ b/poll/main/tests.py
@@ -137,6 +137,7 @@ class QuestionDetailViewTests(TestCase):
         self.assertTrue(response.context["has_answers"])
         self.assertContains(response, "Download CSV")
         self.assertContains(response, "preferenceChart")
+        self.assertContains(response, "eloChart")
 
     def test_question_answers_csv_view(self):
         q = Question.objects.create(text="q", choices=["A", "B"])
@@ -246,3 +247,13 @@ class ChartAPITests(TestCase):
         data = response.json()
         self.assertEqual(data["matrix"][0][1], 1)
         self.assertEqual(data["matrix"][1][0], 0)
+
+    def test_elo_ratings_endpoint(self):
+        url = f"/api/charts/questions/{self.question.uuid}/elo-ratings"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        rankings = data["rankings"]
+        self.assertEqual(len(rankings), 2)
+        # Winner order may depend on algorithm; just check keys
+        self.assertEqual({r["choice"] for r in rankings}, {"X", "Y"})


### PR DESCRIPTION
## Summary
- implement `/api/charts/questions/{uuid}/elo-ratings` returning Elo-style rankings
- display league table chart on question detail page
- test new endpoint and page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_6870921b2f1c8328be00e921d6882f9b