### PR TITLE
Add confidence distribution chart

### DIFF
--- a/poll/main/templates/main/question_detail.html
+++ b/poll/main/templates/main/question_detail.html
@@ -66,6 +66,8 @@
 <canvas id="heatmapChart" height="300"></canvas>
 <h3 class="mt-4">Ranked league table</h3>
 <canvas id="eloChart" height="150"></canvas>
+<h3 class="mt-4">Answer confidence distribution</h3>
+<canvas id="confidenceChart" height="120"></canvas>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@1.3.0/dist/chartjs-chart-matrix.min.js" crossorigin="anonymous"></script>
 <script>
@@ -73,10 +75,12 @@
   const ctx = document.getElementById('preferenceChart').getContext('2d');
   const heatCtx = document.getElementById('heatmapChart').getContext('2d');
   const eloCtx = document.getElementById('eloChart').getContext('2d');
+  const confCtx = document.getElementById('confidenceChart').getContext('2d');
   const filters = document.querySelectorAll('.context-filter');
   let chart;
   let heatmap;
   let eloChart;
+  let confChart;
 
   async function loadChart() {
     const params = new URLSearchParams();
@@ -198,7 +202,36 @@
     }
   }
 
-  function reloadAll() { loadChart(); loadHeatmap(); loadElo(); }
+  async function loadConfidence() {
+    const params = new URLSearchParams();
+    filters.forEach(sel => { if (sel.value) params.append(sel.dataset.key, sel.value); });
+    const resp = await fetch(`/api/charts/questions/${questionUuid}/confidence-distribution?` + params.toString());
+    const data = await resp.json();
+    const labels = data.labels || [];
+    const counts = data.counts || [];
+    if (confChart) {
+      confChart.data.labels = labels;
+      confChart.data.datasets[0].data = counts;
+      confChart.update();
+    } else {
+      confChart = new Chart(confCtx, {
+        type: 'bar',
+        data: {
+          labels: labels,
+          datasets: [{
+            label: 'Answer count',
+            data: counts,
+            backgroundColor: 'rgba(153, 102, 255, 0.5)',
+            borderColor: 'rgba(153, 102, 255, 1)',
+            borderWidth: 1
+          }]
+        },
+        options: { scales: { y: { beginAtZero: true, ticks: { precision: 0 } } } }
+      });
+    }
+  }
+
+  function reloadAll() { loadChart(); loadHeatmap(); loadElo(); loadConfidence(); }
   filters.forEach(sel => sel.addEventListener('change', reloadAll));
   reloadAll();
 </script>

--- a/poll/main/tests.py
+++ b/poll/main/tests.py
@@ -138,6 +138,7 @@ class QuestionDetailViewTests(TestCase):
         self.assertContains(response, "Download CSV")
         self.assertContains(response, "preferenceChart")
         self.assertContains(response, "eloChart")
+        self.assertContains(response, "confidenceChart")
 
     def test_question_answers_csv_view(self):
         q = Question.objects.create(text="q", choices=["A", "B"])
@@ -208,6 +209,7 @@ class ChartAPITests(TestCase):
             context={"gender": "man"},
             choices={"A": "X", "B": "Y"},
             choice="A",
+            confidence=0.8,
         )
         Answer.objects.create(
             question=self.question,
@@ -215,6 +217,7 @@ class ChartAPITests(TestCase):
             context={"gender": "woman"},
             choices={"A": "X", "B": "Y"},
             choice="B",
+            confidence=0.6,
         )
 
     def test_preference_counts_endpoint(self):
@@ -257,3 +260,11 @@ class ChartAPITests(TestCase):
         self.assertEqual(len(rankings), 2)
         # Winner order may depend on algorithm; just check keys
         self.assertEqual({r["choice"] for r in rankings}, {"X", "Y"})
+
+    def test_confidence_distribution_endpoint(self):
+        url = f"/api/charts/questions/{self.question.uuid}/confidence-distribution"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["counts"][8], 1)
+        self.assertEqual(data["counts"][6], 1)


### PR DESCRIPTION
## Summary
- add confidence distribution API endpoint
- show confidence distribution chart on question detail page
- test that new endpoint and chart works

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_b_687095b1162083288a375d06faaa0242