### PR TITLE
Add batch metadata display

### DIFF
--- a/poll/main/models.py
+++ b/poll/main/models.py
@@ -211,6 +211,27 @@ class OpenAIBatch(models.Model):
     def error_file_id(self) -> str | None:
         return self.data.get("error_file_id")
 
+    @property
+    def request_count_total(self) -> int | None:
+        """Return the total number of requests in this batch."""
+        rc = self.data.get("request_counts") or {}
+        try:
+            return int(rc.get("total"))
+        except (TypeError, ValueError):
+            return None
+
+    @property
+    def duration_seconds(self) -> int | None:
+        """Return how long the batch took to complete in seconds."""
+        created = self.data.get("created_at")
+        completed = self.data.get("completed_at")
+        try:
+            if created is not None and completed is not None:
+                return int(completed) - int(created)
+        except (TypeError, ValueError):
+            pass
+        return None
+
     class Meta:
         verbose_name_plural = "OpenAI Batches"
 

--- a/poll/main/templates/main/question_detail.html
+++ b/poll/main/templates/main/question_detail.html
@@ -14,6 +14,16 @@
 <div class="mb-3">
   <strong>Total LLM queries:</strong> {{ total_queries }}
 </div>
+{% if batch_total_queries %}
+<div class="mb-3">
+  <strong>Batch queries processed:</strong> {{ batch_total_queries }}
+</div>
+{% endif %}
+{% if batch_duration %}
+<div class="mb-3">
+  <strong>Batch duration (s):</strong> {{ batch_duration }}
+</div>
+{% endif %}
 
 <h2 class="mt-5">Batches</h2>
 <table class="table table-bordered">

--- a/poll/main/views.py
+++ b/poll/main/views.py
@@ -13,6 +13,9 @@ def question_detail(request, uuid):
     choice_pairs = question.choice_pairs()
     total_queries = len(rendered_questions) * len(choice_pairs)
     batches = question.openai_batches.all().order_by("-created_at")
+    latest_batch = batches.first()
+    batch_total_queries = latest_batch.request_count_total if latest_batch else None
+    batch_duration = latest_batch.duration_seconds if latest_batch else None
 
     answers = question.latest_answers()
     has_answers = answers.exists()
@@ -22,6 +25,8 @@ def question_detail(request, uuid):
         "num_variations": num_variations,
         "total_queries": total_queries,
         "batches": batches,
+        "batch_total_queries": batch_total_queries,
+        "batch_duration": batch_duration,
         "has_answers": has_answers,
     }
     return render(request, "main/question_detail.html", context)


### PR DESCRIPTION
## Summary
- compute batch request counts and duration in seconds
- expose new metadata in question detail view and template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6870e104f7788328937ca4e360683b49