### PR TITLE
Display batch status on question list

### DIFF
--- a/poll/main/models.py
+++ b/poll/main/models.py
@@ -184,6 +184,14 @@ class Question(models.Model):
             return Answer.objects.none()
         return Answer.objects.filter(question=self, run_id=last_batch.run_id)
 
+    @property
+    def latest_batch_status(self) -> str:
+        """Return the status of the most recently created batch."""
+        last_batch = self.openai_batches.order_by("-created_at").first()
+        if last_batch and last_batch.status:
+            return str(last_batch.status)
+        return "queued"
+
 
 class OpenAIBatch(models.Model):
     question = models.ForeignKey(

--- a/poll/main/templates/main/question_list.html
+++ b/poll/main/templates/main/question_list.html
@@ -6,8 +6,11 @@
 <h1 class="h3 mb-4">Questions</h1>
 <div class="list-group">
   {% for q in questions %}
-  <a href="{% url 'polls:question_detail' q.uuid %}" class="list-group-item list-group-item-action">
-    {{ q.text|truncatechars:80 }}
+  <a href="{% url 'polls:question_detail' q.uuid %}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+    <span>{{ q.text|truncatechars:80 }}</span>
+    <span class="badge {% if q.latest_batch_status == 'completed' %}bg-success{% elif q.latest_batch_status == 'running' %}bg-info{% elif q.latest_batch_status == 'failed' %}bg-danger{% else %}bg-secondary{% endif %}">
+      {{ q.latest_batch_status|title }}
+    </span>
   </a>
   {% empty %}
   <div class="alert alert-info">No questions.</div>

--- a/poll/main/tests.py
+++ b/poll/main/tests.py
@@ -176,6 +176,18 @@ class QuestionListViewTests(TestCase):
         self.assertNotContains(response, q2.text)
         self.assertContains(response, reverse("polls:question_detail", args=[q1.uuid]))
 
+    def test_question_list_view_shows_status(self):
+        q1 = Question.objects.create(text="Where?", choices=["A", "B"])
+        OpenAIBatch.objects.create(question=q1, data={"id": "b1", "status": "running"})
+        q2 = Question.objects.create(text="Another?", choices=["A", "B"])
+
+        url = reverse("polls:question_list")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Running")
+        self.assertContains(response, "Queued")
+
 
 class AnswerAdminTests(TestCase):
     def setUp(self):

--- a/poll/main/views.py
+++ b/poll/main/views.py
@@ -7,7 +7,11 @@ from .models import Question
 
 
 def question_list(request):
-    questions = Question.objects.filter(archived=False).order_by("-created_at")
+    questions = (
+        Question.objects.filter(archived=False)
+        .order_by("-created_at")
+        .prefetch_related("openai_batches")
+    )
     return render(request, "main/question_list.html", {"questions": questions})
 
 


### PR DESCRIPTION
## Summary
- show status of latest OpenAI batch for questions
- default to `queued` when no batch exists
- prefetch batches for question list
- cover status display with tests

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_687119f595448328addd65d84ad15d3b