### PR TITLE
Add poll question creation page

### DIFF
--- a/poll/main/forms.py
+++ b/poll/main/forms.py
@@ -1,0 +1,41 @@
+from django import forms
+import json
+
+from .models import Question
+
+class QuestionForm(forms.ModelForm):
+    context = forms.CharField(
+        required=False,
+        widget=forms.Textarea(attrs={'rows': 3, 'class': 'form-control'})
+    )
+    choices = forms.CharField(
+        widget=forms.Textarea(attrs={'rows': 4, 'class': 'form-control'})
+    )
+
+    class Meta:
+        model = Question
+        fields = ['text', 'context', 'choices']
+        widgets = {
+            'text': forms.Textarea(attrs={'rows': 3, 'class': 'form-control'}),
+        }
+
+    def clean_context(self):
+        data = self.cleaned_data.get('context')
+        if not data:
+            return {}
+        if isinstance(data, dict):
+            return data
+        try:
+            return json.loads(data)
+        except json.JSONDecodeError as exc:
+            raise forms.ValidationError('Enter valid JSON') from exc
+
+    def clean_choices(self):
+        data = self.cleaned_data.get('choices')
+        if not data:
+            return []
+        if isinstance(data, list):
+            return data
+        # split by newlines
+        return [line.strip() for line in str(data).splitlines() if line.strip()]
+

--- a/poll/main/templates/main/question_form.html
+++ b/poll/main/templates/main/question_form.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block title %}Create Question{% endblock %}
+
+{% block content %}
+<div class="container-xxl">
+  <div class="d-flex align-items-start justify-content-between mb-4">
+    <h1 class="h3 mb-0">New Question</h1>
+    <a class="btn btn-outline-secondary" href="{% url 'polls:question_list' %}">← Back to list</a>
+  </div>
+  <form method="post" novalidate>
+    {% csrf_token %}
+    <div class="mb-3">
+      <label class="form-label">Question Text</label>
+      {{ form.text }}
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Demographic Options (JSON)</label>
+      {{ form.context }}
+      <div class="form-text">e.g. {"gender": ["man", "woman"]}</div>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Choices (one per line)</label>
+      {{ form.choices }}
+    </div>
+    <button type="submit" class="btn btn-primary">Create</button>
+  </form>
+</div>
+{% endblock %}

--- a/poll/main/templates/main/question_list.html
+++ b/poll/main/templates/main/question_list.html
@@ -3,7 +3,10 @@
 {% block title %}Questions{% endblock %}
 
 {% block content %}
-<h1 class="h3 mb-4">Questions</h1>
+<div class="d-flex align-items-center justify-content-between mb-4">
+  <h1 class="h3 mb-0">Questions</h1>
+  <a class="btn btn-primary" href="{% url 'polls:question_create' %}">New Question</a>
+</div>
 <div class="list-group">
   {% for q in questions %}
   <a href="{% url 'polls:question_detail' q.uuid %}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">

--- a/poll/main/tests.py
+++ b/poll/main/tests.py
@@ -189,6 +189,26 @@ class QuestionListViewTests(TestCase):
         self.assertContains(response, "Queued")
 
 
+class QuestionCreateViewTests(TestCase):
+    def test_get_create_view(self):
+        url = reverse("polls:question_create")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_post_create_view(self):
+        url = reverse("polls:question_create")
+        data = {
+            "text": "Where to go?",
+            "context": json.dumps({"gender": ["man", "woman"]}),
+            "choices": "Turkey\nMexico",
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 302)
+        q = Question.objects.first()
+        self.assertIsNotNone(q)
+        self.assertEqual(q.text, "Where to go?")
+
+
 class AnswerAdminTests(TestCase):
     def setUp(self):
         self.admin_site = AdminSite()

--- a/poll/main/urls.py
+++ b/poll/main/urls.py
@@ -6,6 +6,7 @@ app_name = 'polls'
 
 urlpatterns = [
     path('<uuid:uuid>/answers.csv', views.question_answers_csv, name='question_answers_csv'),
+    path('create/', views.question_create, name='question_create'),
     path('<uuid:uuid>/', views.question_detail, name='question_detail'),
     path('', views.question_list, name='question_list'),
 ]

--- a/poll/main/views.py
+++ b/poll/main/views.py
@@ -1,9 +1,10 @@
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, render, redirect
 from django.http import HttpResponse
 import csv
 import json
 
 from .models import Question
+from .forms import QuestionForm
 
 
 def question_list(request):
@@ -61,3 +62,15 @@ def question_answers_csv(request, uuid):
         ])
 
     return response
+
+
+def question_create(request):
+    if request.method == "POST":
+        form = QuestionForm(request.POST)
+        if form.is_valid():
+            question = form.save()
+            return redirect("polls:question_detail", uuid=question.uuid)
+    else:
+        form = QuestionForm()
+
+    return render(request, "main/question_form.html", {"form": form})


### PR DESCRIPTION
## Summary
- create a `QuestionForm` to parse demographic context and choices
- add a view/template to create questions
- link from question list page
- test the new create view

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_68711d7a7c808328baa7f0e2988cd940