### PR TITLE
Add poll creation endpoint

### DIFF
--- a/poll/api.py
+++ b/poll/api.py
@@ -1,4 +1,4 @@
-from ninja import NinjaAPI, Router
+from ninja import NinjaAPI, Router, Schema
 from django.shortcuts import get_object_or_404
 
 from .main.models import Question
@@ -6,6 +6,23 @@ from .main.models import Question
 api = NinjaAPI()
 
 chart_router = Router()
+question_router = Router()
+
+
+class QuestionCreateSchema(Schema):
+    text: str
+    context: dict | None = None
+    choices: list[str]
+
+
+@question_router.post("")
+def create_question(request, payload: QuestionCreateSchema):
+    question = Question.objects.create(
+        text=payload.text,
+        context=payload.context or {},
+        choices=payload.choices,
+    )
+    return api.create_response(request, {"uuid": str(question.uuid)}, status=201)
 
 @chart_router.get("questions/{uuid}/preference-counts")
 def preference_counts(request, uuid: str):
@@ -155,3 +172,4 @@ def preference_flows(request, uuid: str):
     return {"labels": labels, "links": links}
 
 api.add_router("/charts/", chart_router)
+api.add_router("/questions/", question_router)

--- a/poll/main/tests.py
+++ b/poll/main/tests.py
@@ -326,3 +326,26 @@ class ChartAPITests(TestCase):
         self.assertIn("X", labels)
         self.assertIn("Y", labels)
         self.assertEqual(len(links), 2)
+
+
+class QuestionAPITests(TestCase):
+    def test_create_question(self):
+        payload = {
+            "text": "Where to travel?",
+            "context": {"gender": ["man", "woman"]},
+            "choices": ["Turkey", "Mexico"],
+        }
+
+        response = self.client.post(
+            "/api/questions/",
+            json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertIn("uuid", data)
+        q = Question.objects.get(uuid=data["uuid"])
+        self.assertEqual(q.text, payload["text"])
+        self.assertEqual(q.context, payload["context"])
+        self.assertEqual(q.choices, payload["choices"])


### PR DESCRIPTION
## Summary
- add POST /api/questions endpoint
- test creating a question via API

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_6871ea8a4b24832882937850f9a55a75