### PR TITLE
Add query count on create page and readonly review

### DIFF
--- a/poll/main/templates/main/question_form.html
+++ b/poll/main/templates/main/question_form.html
@@ -40,6 +40,12 @@
       {{ form.choices }}
     </div>
 
+    <div class="alert alert-info">
+      <span id="count-context">1</span> context combinations ×
+      <span id="count-pairs">0</span> choice pairs =
+      <strong><span id="count-total">0</span> total queries</strong>
+    </div>
+
     <button type="submit" class="btn btn-primary">Create</button>
   </form>
 </div>
@@ -53,12 +59,12 @@
     document.addEventListener("DOMContentLoaded", function () {
       const demographicsContainer = document.getElementById("demographics-container");
       const hiddenField = document.getElementById("{{ form.context.id_for_label }}");
+      const choicesField = document.getElementById("{{ form.choices.id_for_label }}");
 
       // Build JSON from current inputs and sync to hidden field
       const categoryRows = [];
 
       function updateDemographicsJSON() {
-        console.log("Updating demographics JSON");
         const result = {};
         categoryRows.forEach(({ input, tagify }) => {
           const key = input.value.trim();
@@ -66,16 +72,14 @@
           const values = tagify.value
             .map((t) => (typeof t === "string" ? t.trim() : String(t.value || "").trim()))
             .filter(Boolean);
-          console.log(" -", key, values);
           if (values.length) result[key] = values;
         });
         hiddenField.value = JSON.stringify(result);
-        console.log("Context field value:", hiddenField.value);
+        updateCounts();
       }
 
       // Helper to create a new category row
       function createCategoryRow(key = "", values = []) {
-        console.log("Creating category row", key, values);
         const row = document.createElement("div");
         row.className = "d-flex align-items-start gap-2 mb-2";
         row.innerHTML = `
@@ -100,7 +104,6 @@
 
         // Remove row handler
         row.querySelector(".remove-category").addEventListener("click", () => {
-          console.log("Removing category row", key);
           const idx = categoryRows.findIndex((r) => r.row === row);
           if (idx > -1) categoryRows.splice(idx, 1);
           row.remove();
@@ -126,6 +129,40 @@
 
       // Before form submit, build JSON and push into hidden field one last time
       demographicsContainer.closest("form").addEventListener("submit", updateDemographicsJSON);
+
+      choicesField.addEventListener("input", updateCounts);
+
+      function countContextCombinations() {
+        if (!hiddenField.value) return 1;
+        try {
+          const ctx = JSON.parse(hiddenField.value);
+          let count = 1;
+          Object.values(ctx).forEach(vals => {
+            const len = Array.isArray(vals) ? vals.length : 1;
+            count *= Math.max(len, 1);
+          });
+          return count;
+        } catch (e) { return 1; }
+      }
+
+      function countChoicePairs() {
+        const choices = choicesField.value.split(/\r?\n/).map(v => v.trim()).filter(Boolean);
+        const unique = Array.from(new Set(choices));
+        const n = unique.length;
+        return n < 2 ? 0 : n * (n - 1) / 2;
+      }
+
+      function updateCounts() {
+        const ctxCnt = countContextCombinations();
+        const pairCnt = countChoicePairs();
+        const total = ctxCnt * pairCnt;
+        document.getElementById("count-context").textContent = ctxCnt;
+        document.getElementById("count-pairs").textContent = pairCnt;
+        document.getElementById("count-total").textContent = total;
+      }
+
+      updateDemographicsJSON();
+      updateCounts();
     });
   </script>
 {% endblock %}

--- a/poll/main/templates/main/question_review.html
+++ b/poll/main/templates/main/question_review.html
@@ -2,11 +2,6 @@
 
 {% block title %}Review Question{% endblock %}
 
-{% block extra_css %}
-  {{ block.super }}
-  <link rel="stylesheet" href="https://unpkg.com/@yaireo/tagify/dist/tagify.css">
-{% endblock %}
-
 {% block content %}
 <div class="container-xxl">
   <div class="d-flex align-items-start justify-content-between mb-4">
@@ -14,142 +9,43 @@
     <a class="btn btn-outline-secondary" href="{% url 'polls:question_list' %}">← Back to list</a>
   </div>
 
-  <form method="post" novalidate>
+  <div class="mb-4">
+    <h2 class="h5">Question</h2>
+    <pre class="mb-0">{{ question.text }}</pre>
+  </div>
+
+  {% if question.context %}
+  <div class="mb-4">
+    <h2 class="h5">Context Parameters</h2>
+    <ul class="list-group">
+      {% for key, vals in question.context.items %}
+      <li class="list-group-item">
+        <strong>{{ key }}:</strong> {{ vals|join:", " }}
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
+
+  <div class="mb-4">
+    <h2 class="h5">Choices</h2>
+    <ul class="list-group">
+      {% for c in question.choices %}
+      <li class="list-group-item">{{ c }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+
+  <div class="alert alert-info">
+    <div><strong>Context combinations:</strong> {{ num_variations }}</div>
+    <div><strong>Choice pairs:</strong> {{ num_choice_pairs }}</div>
+    <div><strong>Total queries:</strong> {{ total_queries }}</div>
+  </div>
+
+  <form method="post" class="d-flex gap-2 mt-3">
     {% csrf_token %}
-
-    <div class="mb-3">
-      <label class="form-label">Question Text</label>
-      {{ form.text }}
-    </div>
-
-    <div class="mb-3">
-      <label class="form-label mb-1">Demographic Options</label>
-      <div id="demographics-container"></div>
-      <button type="button" id="add-category" class="btn btn-sm btn-outline-primary mt-2">Add category</button>
-      <div class="d-none">
-        {{ form.context }}
-      </div>
-    </div>
-
-    <div class="mb-3">
-      <label class="form-label">Choices (one per line)</label>
-      {{ form.choices }}
-    </div>
-
-    <div class="alert alert-info">
-      <div><strong>Context combinations:</strong> <span id="count-context">0</span></div>
-      <div><strong>Choice pairs:</strong> <span id="count-pairs">0</span></div>
-      <div><strong>Total queries:</strong> <span id="count-total">0</span></div>
-    </div>
-
-    <button type="submit" name="submit" class="btn btn-primary">Approve &amp; Submit</button>
+    <a href="{% url 'polls:question_create' %}?uuid={{ question.uuid }}" class="btn btn-outline-secondary">Edit</a>
+    <button type="submit" class="btn btn-primary">Submit for Processing</button>
   </form>
 </div>
-{% endblock %}
-
-{% block extra_js %}
-  {{ block.super }}
-  <script src="https://unpkg.com/@yaireo/tagify"></script>
-  <script>
-    document.addEventListener("DOMContentLoaded", function () {
-      const demographicsContainer = document.getElementById("demographics-container");
-      const hiddenField = document.getElementById("{{ form.context.id_for_label }}");
-      const choicesField = document.getElementById("{{ form.choices.id_for_label }}");
-
-      const categoryRows = [];
-
-      function updateDemographicsJSON() {
-        const result = {};
-        categoryRows.forEach(({ input, tagify }) => {
-          const key = input.value.trim();
-          if (!key || !tagify) return;
-          const values = tagify.value
-            .map((t) => (typeof t === "string" ? t.trim() : String(t.value || "").trim()))
-            .filter(Boolean);
-          if (values.length) result[key] = values;
-        });
-        hiddenField.value = JSON.stringify(result);
-        updateCounts();
-      }
-
-      function createCategoryRow(key = "", values = []) {
-        const row = document.createElement("div");
-        row.className = "d-flex align-items-start gap-2 mb-2";
-        row.innerHTML = `
-          <input type="text" class="form-control w-25 category-input" placeholder="Category (e.g. gender)" value="${key}">
-          <input type="text" class="form-control flex-fill tags-input" placeholder="Options (press Enter after each)">
-          <button type="button" class="btn btn-outline-danger remove-category">✕</button>
-        `;
-        demographicsContainer.appendChild(row);
-
-        const tagInput = row.querySelector(".tags-input");
-        const tagify = new Tagify(tagInput, {
-          originalInputValueFormat: (valuesArray) => valuesArray.map((item) => item.value),
-        });
-        tagify.on("add remove", updateDemographicsJSON);
-        tagInput.addEventListener("change", updateDemographicsJSON);
-        tagify.addTags(values);
-
-        const categoryInput = row.querySelector(".category-input");
-        categoryRows.push({ row, input: categoryInput, tagify });
-
-        row.querySelector(".remove-category").addEventListener("click", () => {
-          const idx = categoryRows.findIndex((r) => r.row === row);
-          if (idx > -1) categoryRows.splice(idx, 1);
-          row.remove();
-          updateDemographicsJSON();
-        });
-        categoryInput.addEventListener("input", updateDemographicsJSON);
-      }
-
-      try {
-        const existing = hiddenField.value ? JSON.parse(hiddenField.value) : {};
-        Object.entries(existing).forEach(([k, v]) => createCategoryRow(k, v));
-        if (!Object.keys(existing).length) createCategoryRow();
-      } catch (e) {
-        createCategoryRow();
-      }
-
-      document.getElementById("add-category").addEventListener("click", () => {
-        createCategoryRow();
-        updateDemographicsJSON();
-      });
-
-      demographicsContainer.closest("form").addEventListener("submit", updateDemographicsJSON);
-
-      choicesField.addEventListener("input", updateCounts);
-
-      function countContextCombinations() {
-        if (!hiddenField.value) return 1;
-        try {
-          const ctx = JSON.parse(hiddenField.value);
-          let count = 1;
-          Object.values(ctx).forEach(vals => {
-            const len = Array.isArray(vals) ? vals.length : 1;
-            count *= Math.max(len, 1);
-          });
-          return count;
-        } catch (e) { return 1; }
-      }
-
-      function countChoicePairs() {
-        const choices = choicesField.value.split(/\r?\n/).map(v => v.trim()).filter(Boolean);
-        const unique = Array.from(new Set(choices));
-        const n = unique.length;
-        return n < 2 ? 0 : n * (n - 1) / 2;
-      }
-
-      function updateCounts() {
-        const ctxCnt = countContextCombinations();
-        const pairCnt = countChoicePairs();
-        const total = ctxCnt * pairCnt;
-        document.getElementById("count-context").textContent = ctxCnt;
-        document.getElementById("count-pairs").textContent = pairCnt;
-        document.getElementById("count-total").textContent = total;
-      }
-
-      updateDemographicsJSON();
-      updateCounts();
-    });
-  </script>
 {% endblock %}

--- a/poll/main/tests.py
+++ b/poll/main/tests.py
@@ -212,13 +212,8 @@ class QuestionCreateViewTests(TestCase):
     def test_post_review_submits_batches(self):
         q = Question.objects.create(text="T?", choices=["A", "B"])
         url = reverse("polls:question_review", args=[q.uuid])
-        data = {
-            "text": "T?",
-            "context": json.dumps({}),
-            "choices": "A\nB",
-        }
         with patch.object(Question, "submit_batches") as sb:
-            response = self.client.post(url, data)
+            response = self.client.post(url)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response["Location"], reverse("polls:question_detail", args=[q.uuid]))
         sb.assert_called_once()


### PR DESCRIPTION
## Summary
- show live total query count while creating a question
- make question review screen read only and allow editing via create form
- adjust submission view logic and tests

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_687298c126188328a86e6c56ddf9240b