### PR TITLE
Make draft questions clickable

### DIFF
--- a/poll/main/templates/main/question_list.html
+++ b/poll/main/templates/main/question_list.html
@@ -35,7 +35,7 @@
       {% with latest=q.openai_batches.all|first %}
       <div class="list-group-item question-item px-2">
         <div class="d-flex justify-content-between align-items-center">
-          <a class="question-link flex-grow-1 me-3 text-black text-decoration-none d-flex justify-content-between align-items-center" data-target-href="{% url 'polls:question_results' q.uuid %}" data-batch-id="{{ latest.batch_id|default:'' }}" {% if q.status == 'completed' %}href="{% url 'polls:question_results' q.uuid %}"{% endif %}>
+          <a class="question-link flex-grow-1 me-3 text-black text-decoration-none d-flex justify-content-between align-items-center" data-target-href="{% url 'polls:question_results' q.uuid %}" data-batch-id="{{ latest.batch_id|default:'' }}" {% if q.status == 'completed' %}href="{% url 'polls:question_results' q.uuid %}"{% elif q.status == 'draft' %}href="{% url 'polls:question_create' %}?uuid={{ q.uuid }}"{% endif %}>
             <span>{{ q.text|truncatechars:80 }}</span>
             <span class="badge {% if q.status == 'completed' %}bg-success{% elif q.status == 'running' %}bg-info{% elif q.status == 'failed' %}bg-danger{% elif q.status == 'importing' %}bg-warning text-dark{% else %}bg-secondary{% endif %}">
               {{ q.status|title }}
@@ -88,7 +88,7 @@
       {% with latest=q.openai_batches.all|first %}
       <div class="list-group-item question-item">
         <div class="d-flex justify-content-between align-items-center">
-          <a class="question-link flex-grow-1 me-3 text-black text-decoration-none d-flex justify-content-between align-items-center" data-target-href="{% url 'polls:question_results' q.uuid %}" data-batch-id="{{ latest.batch_id|default:'' }}" {% if q.status == 'completed' %}href="{% url 'polls:question_results' q.uuid %}"{% endif %}>
+          <a class="question-link flex-grow-1 me-3 text-black text-decoration-none d-flex justify-content-between align-items-center" data-target-href="{% url 'polls:question_results' q.uuid %}" data-batch-id="{{ latest.batch_id|default:'' }}" {% if q.status == 'completed' %}href="{% url 'polls:question_results' q.uuid %}"{% elif q.status == 'draft' %}href="{% url 'polls:question_create' %}?uuid={{ q.uuid }}"{% endif %}>
             <span>{{ q.text|truncatechars:80 }}</span>
             <span class="badge {% if q.status == 'completed' %}bg-success{% elif q.status == 'running' %}bg-info{% elif q.status == 'failed' %}bg-danger{% elif q.status == 'importing' %}bg-warning text-dark{% else %}bg-secondary{% endif %}">
               {{ q.status|title }}
@@ -135,7 +135,7 @@
       {% with latest=q.openai_batches.all|first %}
       <div class="list-group-item question-item">
         <div class="d-flex justify-content-between align-items-center">
-          <a class="question-link flex-grow-1 me-3 text-black text-decoration-none d-flex justify-content-between align-items-center" data-target-href="{% url 'polls:question_results' q.uuid %}" data-batch-id="{{ latest.batch_id|default:'' }}" {% if q.status == 'completed' %}href="{% url 'polls:question_results' q.uuid %}"{% endif %}>
+          <a class="question-link flex-grow-1 me-3 text-black text-decoration-none d-flex justify-content-between align-items-center" data-target-href="{% url 'polls:question_results' q.uuid %}" data-batch-id="{{ latest.batch_id|default:'' }}" {% if q.status == 'completed' %}href="{% url 'polls:question_results' q.uuid %}"{% elif q.status == 'draft' %}href="{% url 'polls:question_create' %}?uuid={{ q.uuid }}"{% endif %}>
             <span>{{ q.text|truncatechars:80 }}</span>
             <span class="badge {% if q.status == 'completed' %}bg-success{% elif q.status == 'running' %}bg-info{% elif q.status == 'failed' %}bg-danger{% elif q.status == 'importing' %}bg-warning text-dark{% else %}bg-secondary{% endif %}">
               {{ q.status|title }}

--- a/poll/main/tests.py
+++ b/poll/main/tests.py
@@ -201,6 +201,13 @@ class QuestionListViewTests(TestCase):
         self.assertContains(response, "Running")
         self.assertContains(response, "Draft")
 
+    def test_draft_question_links_to_edit(self):
+        q = Question.objects.create(text="Edit?", choices=["A", "B"], user=self.user)
+        url = reverse("polls:question_list")
+        response = self.client.get(url)
+        edit_url = f"{reverse('polls:question_create')}?uuid={q.uuid}"
+        self.assertContains(response, f'href="{edit_url}"')
+
 
 class QuestionCreateViewTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- let draft questions link to the edit form from the list page
- add test for draft link

## Testing
- `python manage.py test -v 1`

------
https://chatgpt.com/codex/tasks/task_b_68754172d72c8328b344034b8ae2c17c