### PR TITLE
Add examples home page

### DIFF
--- a/poll/examples/templates/examples/home.html
+++ b/poll/examples/templates/examples/home.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block title %}Examples{% endblock %}
+
+{% block content %}
+<h1 class="h3 mb-4">Examples</h1>
+<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+  {% for example in examples %}
+  <div class="col">
+    <div class="card h-100">
+      <div class="card-body">
+        <h5 class="card-title">{{ example.title }}</h5>
+        <p class="card-text">{{ example.description }}</p>
+      </div>
+      {% with example.questions.all|slice:':2' as sample_qs %}
+      {% if sample_qs %}
+      <ul class="list-group list-group-flush">
+        {% for q in sample_qs %}
+        <li class="list-group-item">
+          <a href="{% url 'polls:question_results' q.uuid %}">{{ q.text|truncatechars:80 }}</a>
+        </li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+      {% endwith %}
+    </div>
+  </div>
+  {% empty %}
+  <p>No examples available.</p>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/poll/examples/urls.py
+++ b/poll/examples/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from . import views
+
+app_name = 'examples'
+
+urlpatterns = [
+    path('', views.home, name='home'),
+]

--- a/poll/examples/views.py
+++ b/poll/examples/views.py
@@ -1,3 +1,9 @@
 from django.shortcuts import render
 
-# Create your views here.
+from .models import Example
+
+
+def home(request):
+    """Display example use cases with sample questions."""
+    examples = Example.objects.prefetch_related('questions')
+    return render(request, 'examples/home.html', {'examples': examples})

--- a/poll/urls.py
+++ b/poll/urls.py
@@ -5,6 +5,7 @@ from .api import api
 
 
 urlpatterns = [
+    path('', include('poll.examples.urls')),
     path('admin/', admin.site.urls),
     path('polls/', include('poll.main.urls')),
     path('api/', api.urls),


### PR DESCRIPTION
## Summary
- add a new home page for Example cards
- wire up `examples.urls` at the project root

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_687555318aac8328903f88eeb1fe0577