### PR TITLE
Add examples tab for question list

### DIFF
--- a/poll/main/templates/main/question_list.html
+++ b/poll/main/templates/main/question_list.html
@@ -21,6 +21,9 @@
     <button class="nav-link active" id="active-tab" data-bs-toggle="tab" data-bs-target="#active" type="button" role="tab" aria-controls="active" aria-selected="true">Active</button>
   </li>
   <li class="nav-item" role="presentation">
+    <button class="nav-link" id="examples-tab" data-bs-toggle="tab" data-bs-target="#examples" type="button" role="tab" aria-controls="examples" aria-selected="false">Examples</button>
+  </li>
+  <li class="nav-item" role="presentation">
     <button class="nav-link" id="failed-tab" data-bs-toggle="tab" data-bs-target="#failed" type="button" role="tab" aria-controls="failed" aria-selected="false">Failed</button>
   </li>
   <li class="nav-item" role="presentation">
@@ -79,6 +82,38 @@
       {% endwith %}
       {% empty %}
       <div class="alert alert-info mt-3">No questions.</div>
+      {% endfor %}
+    </div>
+  </div>
+  <div class="tab-pane fade" id="examples" role="tabpanel" aria-labelledby="examples-tab">
+    <div class="list-group list-group-flush">
+      {% for q in examples %}
+      {% with latest=q.openai_batches.all|first %}
+      <div class="list-group-item question-item px-2">
+        <div class="d-flex justify-content-between align-items-center">
+          <a class="question-link flex-grow-1 me-3 text-black text-decoration-none d-flex justify-content-between align-items-center" data-target-href="{% url 'polls:question_results' q.uuid %}" data-batch-id="{{ latest.batch_id|default:'' }}" {% if q.status == 'completed' %}href="{% url 'polls:question_results' q.uuid %}"{% elif q.status == 'draft' %}href="{% url 'polls:question_create' %}?uuid={{ q.uuid }}"{% endif %}>
+            <span>{{ q.text|truncatechars:80 }}</span>
+            <span class="badge {% if q.status == 'completed' %}bg-success{% elif q.status == 'running' %}bg-info{% elif q.status == 'failed' %}bg-danger{% elif q.status == 'importing' %}bg-warning text-dark{% else %}bg-secondary{% endif %}">
+              {{ q.status|title }}
+            </span>
+          </a>
+        </div>
+        <div class="small text-muted mt-1">
+          {% if q.context %}
+            By:
+            {% for key, val in q.context.items %}
+              {% if forloop.counter <= 2 %}{{ key }}{% if forloop.counter < 2 and q.context|length > 1 %}, {% endif %}{% endif %}
+            {% endfor %}{% if q.context|length > 2 %}, ...{% endif %}
+          {% endif %}
+          {% if q.choices %}
+            {% if q.context %} | {% endif %}
+            Choices: {{ q.choices|slice:":3"|join:", " }}{% if q.choices|length > 3 %}, ...{% endif %}
+          {% endif %}
+        </div>
+      </div>
+      {% endwith %}
+      {% empty %}
+      <div class="alert alert-info mt-3">No example questions.</div>
       {% endfor %}
     </div>
   </div>

--- a/poll/main/tests.py
+++ b/poll/main/tests.py
@@ -180,12 +180,18 @@ class QuestionListViewTests(TestCase):
         q1 = Question.objects.create(text="Where?", choices=["A", "B"], user=self.user)
         q2 = Question.objects.create(text="Archived?", choices=["A", "B"], archived=True, user=self.user)
 
+        q3 = Question.objects.create(text="Example?", choices=["A", "B"])
+
         url = reverse("polls:question_list")
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, q1.text)
         self.assertContains(response, q2.text)
+        self.assertContains(response, q3.text)
+
+        self.assertIn(q3, response.context["examples"])
+        self.assertNotIn(q3, response.context["active"])
 
     def test_question_list_view_shows_status(self):
         q1 = Question.objects.create(text="Where?", choices=["A", "B"], user=self.user)

--- a/poll/main/views.py
+++ b/poll/main/views.py
@@ -16,6 +16,15 @@ def question_list(request):
         Question.objects.filter(
             archived=False,
             status__in=["draft", "queued", "running", "completed", "importing"],
+            user__isnull=False,
+        )
+        .order_by("-created_at")
+        .prefetch_related("openai_batches")
+    )
+    examples = (
+        Question.objects.filter(
+            archived=False,
+            user__isnull=True,
         )
         .order_by("-created_at")
         .prefetch_related("openai_batches")
@@ -30,7 +39,12 @@ def question_list(request):
         .order_by("-created_at")
         .prefetch_related("openai_batches")
     )
-    context = {"active": active, "failed": failed, "archived": archived}
+    context = {
+        "active": active,
+        "examples": examples,
+        "failed": failed,
+        "archived": archived,
+    }
     return render(request, "main/question_list.html", context)
 
 


### PR DESCRIPTION
## Summary
- add `examples` queryset to question list view and filter active questions by `user__isnull=False`
- display new **Examples** nav tab and tab panel
- test that example questions only show under the examples tab

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_6877fd3c54ec83288ea07282814ecea9