### PR TITLE
Show tags on question list

### DIFF
--- a/poll/main/templates/main/question_list.html
+++ b/poll/main/templates/main/question_list.html
@@ -75,7 +75,16 @@
           {% endif %}
           {% if q.choices %}
             {% if q.context %} | {% endif %}
-            Choices: {{ q.choices|slice:":3"|join:", " }}{% if q.choices|length > 3 %}, ...{% endif %}
+            {% with first=q.choices|slice:":3" %}
+            Choices:
+            {% for choice in first %}
+              {{ choice|truncatechars:20 }}{% if not forloop.last %}, {% endif %}
+            {% endfor %}{% if q.choices|length > 3 %}, ...{% endif %}
+            {% endwith %}
+          {% endif %}
+          {% if q.tags %}
+            {% if q.context or q.choices %} | {% endif %}
+            Tags: {{ q.tags|join:", " }}
           {% endif %}
         </div>
       </div>
@@ -119,7 +128,16 @@
           {% endif %}
           {% if q.choices %}
             {% if q.context %} | {% endif %}
-            Choices: {{ q.choices|slice:":3"|join:", " }}{% if q.choices|length > 3 %}, ...{% endif %}
+            {% with first=q.choices|slice:":3" %}
+            Choices:
+            {% for choice in first %}
+              {{ choice|truncatechars:20 }}{% if not forloop.last %}, {% endif %}
+            {% endfor %}{% if q.choices|length > 3 %}, ...{% endif %}
+            {% endwith %}
+          {% endif %}
+          {% if q.tags %}
+            {% if q.context or q.choices %} | {% endif %}
+            Tags: {{ q.tags|join:", " }}
           {% endif %}
         </div>
       </div>
@@ -166,7 +184,16 @@
           {% endif %}
           {% if q.choices %}
             {% if q.context %} | {% endif %}
-            Choices: {{ q.choices|slice:":3"|join:", " }}{% if q.choices|length > 3 %}, ...{% endif %}
+            {% with first=q.choices|slice:":3" %}
+            Choices:
+            {% for choice in first %}
+              {{ choice|truncatechars:20 }}{% if not forloop.last %}, {% endif %}
+            {% endfor %}{% if q.choices|length > 3 %}, ...{% endif %}
+            {% endwith %}
+          {% endif %}
+          {% if q.tags %}
+            {% if q.context or q.choices %} | {% endif %}
+            Tags: {{ q.tags|join:", " }}
           {% endif %}
         </div>
       </div>
@@ -204,7 +231,16 @@
           {% endif %}
           {% if q.choices %}
             {% if q.context %} | {% endif %}
-            Choices: {{ q.choices|slice:":3"|join:", " }}{% if q.choices|length > 3 %}, ...{% endif %}
+            {% with first=q.choices|slice:":3" %}
+            Choices:
+            {% for choice in first %}
+              {{ choice|truncatechars:20 }}{% if not forloop.last %}, {% endif %}
+            {% endfor %}{% if q.choices|length > 3 %}, ...{% endif %}
+            {% endwith %}
+          {% endif %}
+          {% if q.tags %}
+            {% if q.context or q.choices %} | {% endif %}
+            Tags: {{ q.tags|join:", " }}
           {% endif %}
         </div>
       </div>

--- a/poll/main/tests.py
+++ b/poll/main/tests.py
@@ -214,6 +214,21 @@ class QuestionListViewTests(TestCase):
         edit_url = f"{reverse('polls:question_create')}?uuid={q.uuid}"
         self.assertContains(response, f'href="{edit_url}"')
 
+    def test_list_displays_tags_and_truncates_choices(self):
+        long_choice = "Super long choice name that should be truncated"
+        q = Question.objects.create(
+            text="T", choices=[long_choice, "Short"], tags=["tag1", "tag2"], user=self.user
+        )
+
+        url = reverse("polls:question_list")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Tags: tag1, tag2")
+        from django.utils.text import Truncator
+        truncated = Truncator(long_choice).chars(20)
+        self.assertContains(response, truncated)
+
 
 class QuestionCreateViewTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- show question tags on list view
- shorten choice labels with built-in `truncatechars`
- remove now-unnecessary template filter
- test tags and truncation

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_687893644948832880cb67940b4c8ca9